### PR TITLE
Update Dockerfile (golang 1.22)

### DIFF
--- a/Chapter2/Dockerfile
+++ b/Chapter2/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.17-alpine
+FROM golang:1.22-alpine
 
 RUN apk add curl
 


### PR DESCRIPTION
In 2024 Gin framework won't start with golang v1.17, build fails with message: "note: module requires Go 1.20" 

And updating base image to 1.22 fixes the issue.